### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 >[!IMPORTANT]
-> For most use cases, Plaid Income has been superceded by Plaid Check. Plaid Income should only be used for use cases not covered by Plaid Check, like verifying non-US users or using document-based verification rather than bank-based verification. For everything else, see the [Plaid Check Quickstart](https://github.com/plaid/credit-quickstart). 
+> For most use cases, Plaid Income has been superseded by Plaid Check. Plaid Income should only be used for use cases not covered by Plaid Check, like verifying non-US users or using document-based verification rather than bank-based verification. For everything else, see the [Plaid Check Quickstart](https://github.com/plaid/credit-quickstart). 
 >
 >
 > Customers who begin using Plaid Income on or after December 10, 2025 must contact their account manager or support to request that their account be enabled for user tokens.


### PR DESCRIPTION
Documentation-only fix found during a README audit. No code changes.

- "superceded" → "superseded" in the Plaid Check deprecation note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude Session: ed109da0-3731-4af2-a267-06897819a519