### PR TITLE
Fix misc small bugs; upgrade Chakra to v2

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,9 +8,10 @@
       "name": "incomesample",
       "version": "0.1.0",
       "dependencies": {
-        "@chakra-ui/layout": "^1.8.0",
-        "@chakra-ui/react": "^1.8.9",
-        "@chakra-ui/system": "^1.12.1",
+        "@chakra-ui/react": "^2.8.2",
+        "@emotion/react": "^11.13.0",
+        "@emotion/styled": "^11.13.0",
+        "framer-motion": "^11.5.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-plaid-link": "^4.1.1"
@@ -24,13 +25,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -39,14 +39,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -56,57 +55,52 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -116,42 +110,40 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -159,995 +151,113 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@chakra-ui/accordion": {
-      "version": "1.4.12",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/accordion/-/accordion-1.4.12.tgz",
-      "integrity": "sha512-Hq5Ie1SI4mmtgBmeuir+f7QKgopZEyQOojgufo/A20keMSy5Yk9WZjkXNQgvoIRl1AsoziIPUlubQOtkBZjjbA==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/descendant": "2.1.4",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/icon": "2.0.5",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/transition": "1.4.8",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": "3.x || 4.x || 5.x || 6.x",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/alert": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/alert/-/alert-1.3.7.tgz",
-      "integrity": "sha512-fFpJYBpHOIK/BX4BVl/xafYiDBUW+Bq/gUYDOo4iAiO4vHgxo74oa+yOwSRNlNjAgIX7pi2ridsYQALKyWyxxQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/icon": "2.0.5",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
     "node_modules/@chakra-ui/anatomy": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-1.3.0.tgz",
-      "integrity": "sha512-vj/lcHkCuq/dtbl69DkNsftZTnrGEegB90ODs1B6rxw8iVMdDSYkthPPFAkqzNs4ppv1y2IBjELuVzpeta1OHA==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/theme-tools": "^1.3.6"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0"
-      }
-    },
-    "node_modules/@chakra-ui/avatar": {
-      "version": "1.3.11",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/avatar/-/avatar-1.3.11.tgz",
-      "integrity": "sha512-/eRRK48Er92/QWAfWhxsJIN0gZBBvk+ew4Hglo+pxt3/NDnfTF2yPE7ZN29Dl6daPNbyTOpoksMwaU2mZIqLgA==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/image": "1.1.10",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/breadcrumb": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/breadcrumb/-/breadcrumb-1.3.6.tgz",
-      "integrity": "sha512-iXxienBO6RUnJEcDvyDWyRt+mzPyl7/b6N8i0vrjGKGLpgtayJFvIdo33tFcvx6TCy7V9hiE3HTtZnNomWdR6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/button": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/button/-/button-1.5.10.tgz",
-      "integrity": "sha512-IVEOrleI378CckAa3b3CTUHMPZRfpy6LPwn1Mx3sMpHEkDTKu8zJcjgEvCE8HYzNC1KbwBsa1PfTgk40ui6EtA==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/spinner": "1.2.6",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/checkbox": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/checkbox/-/checkbox-1.7.1.tgz",
-      "integrity": "sha512-9Io97yn8OrdaIynCj+3Z/neJV7lTT1MtcdYh3BKMd7WnoJDkRY/GlBM8zsdgC5Wvm+ZQ1M83t0YvRPKLLzusyA==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/form-control": "1.6.0",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4",
-        "@chakra-ui/visually-hidden": "1.1.6"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": "3.x || 4.x || 5.x || 6.x",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/clickable": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/clickable/-/clickable-1.2.6.tgz",
-      "integrity": "sha512-89SsrQwwwAadcl/bN8nZqqaaVhVNFdBXqQnxVy1t07DL5ezubmNb5SgFh9LDznkm9YYPQhaGr3W6HFro7iAHMg==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/close-button": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/close-button/-/close-button-1.2.7.tgz",
-      "integrity": "sha512-cYTxfgrIlPU4IZm1sehZXxx/TNQBk9c3LBPvTpywEM8GVRGINh4YLq8WiMaPtO+TDNBnKoWS/jS4IHnR+abADw==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/icon": "2.0.5",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/color-mode": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/color-mode/-/color-mode-1.4.8.tgz",
-      "integrity": "sha512-iD4126DVQi06c6ARr3uf3R2rtEu8aBVjW8rhZ+lOsV26Z15iCJA7OAut13Xu06fcZvgjSB/ChDy6Sx9sV9UjHA==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/react-env": "1.1.6",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/control-box": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/control-box/-/control-box-1.1.6.tgz",
-      "integrity": "sha512-EUcq5f854puG6ZA6wAWl4107OPl8+bj4MMHJCa48BB0qec0U8HCEtxQGnFwJmaYLalIAjMfHuY3OwO2A3Hi9hA==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/counter": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/counter/-/counter-1.2.10.tgz",
-      "integrity": "sha512-HQd09IuJ4z8M8vWajH+99jBWWSHDesQZmnN95jUg3HKOuNleLaipf2JFdrqbO1uWQyHobn2PM6u+B+JCAh2nig==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/css-reset": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/css-reset/-/css-reset-1.1.3.tgz",
-      "integrity": "sha512-AgfrE7bRTJvNi/4zIfacI/kBHmHmHEIeQtHwCvk/0qM9V2gK1VM3ctYlnibf7BTh17F/UszweOGRb1lHSPfWjw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@emotion/react": ">=10.0.35",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/descendant": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/descendant/-/descendant-2.1.4.tgz",
-      "integrity": "sha512-k1olHM6c0fcI5fQxO9rqg9rxripcfHMEm2LkORgH0CAzFn/U75CxCw5ec0IMedNWCdiv740enVfnfhBAoSg7gw==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/react-utils": "^1.2.3"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/editable": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/editable/-/editable-1.4.2.tgz",
-      "integrity": "sha512-a5zKghA/IvG7yNkmFl7Z9c2KSsf0FgyijsNPTg/4S5jxyz13QJtoTg40tdpyaxHHCT25y25iUcV4FYCj6Jd01w==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/focus-lock": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/focus-lock/-/focus-lock-1.2.6.tgz",
-      "integrity": "sha512-ZJNE1oNdUM1aGWuCJ+bxFa/d3EwxzfMWzTKzSvKDK50GWoUQQ10xFTT9nY/yFpkcwhBvx1KavxKf44mIhIbSog==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/utils": "1.10.4",
-        "react-focus-lock": "2.5.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/focus-lock/node_modules/react-focus-lock": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.5.2.tgz",
-      "integrity": "sha512-WzpdOnEqjf+/A3EH9opMZWauag7gV0BxFl+EY4ElA4qFqYsUsBLnmo2sELbN5OC30S16GAWMy16B9DLPpdJKAQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "focus-lock": "^0.9.1",
-        "prop-types": "^15.6.2",
-        "react-clientside-effect": "^1.2.5",
-        "use-callback-ref": "^1.2.5",
-        "use-sidecar": "^1.0.5"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@chakra-ui/form-control": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/form-control/-/form-control-1.6.0.tgz",
-      "integrity": "sha512-MtUE98aocP2QTgvyyJ/ABuG33mhT3Ox56phKreG3HzbUKByMwrbQSm1QcAgyYdqSZ9eKB2tXx+qgGNh+avAfDA==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/icon": "2.0.5",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-2.3.6.tgz",
+      "integrity": "sha512-TjmjyQouIZzha/l8JxdBZN1pKZTj7sLpJ0YkFnQFyqHcbfWggW9jKWzY1E0VBnhtFz/xF3KC6UAVuZVSJx+y0g==",
+      "license": "MIT"
     },
     "node_modules/@chakra-ui/hooks": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/hooks/-/hooks-1.9.1.tgz",
-      "integrity": "sha512-SEeh1alDKzrP9gMLWMnXOUDBQDKF/URL6iTmkumTn6vhawWNla6sPrcMyoCzWdMzwUhZp3QNtCKbUm7dxBXvPw==",
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/hooks/-/hooks-2.4.6.tgz",
+      "integrity": "sha512-l+sWr5/QYoM2Pg8hB8GJZRs/hequyVR6eG9vMJjvPU2qVcz43FFzKn/8PHK78shCFA3V3QxeWyJDgwDJOAdBsA==",
       "license": "MIT",
       "dependencies": {
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4",
-        "compute-scroll-into-view": "1.0.14",
-        "copy-to-clipboard": "3.3.1"
+        "@chakra-ui/utils": "2.2.6",
+        "@zag-js/element-size": "0.31.1",
+        "copy-to-clipboard": "3.3.3",
+        "framesync": "6.1.2"
       },
       "peerDependencies": {
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/icon": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-2.0.5.tgz",
-      "integrity": "sha512-ZrqRvCCIxGr4qFd/r1pmtd9tobRmv8KAxV7ygFoc/t4vOSKTcVIjhE12gsI3FzgvXM15ZFVwsxa1zodwgo5neQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/image": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/image/-/image-1.1.10.tgz",
-      "integrity": "sha512-PJZmhQ/R1PgdMyCRjALfoyq1FNh/WzMAw70sliHLtLcb9hBXniwQZuckYfUshCkUoFBj/ow9d4byn9Culdpk7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/input": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/input/-/input-1.4.6.tgz",
-      "integrity": "sha512-Ljy/NbOhh9cNQxKTWQRsT4aQiXs2vVya+Cj5NpMAz08NFFjPZovsTawhI7m6ejT5Vsh76QYjh2rOLLI3fWqQQw==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/form-control": "1.6.0",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/layout": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/layout/-/layout-1.8.0.tgz",
-      "integrity": "sha512-GJtEKez5AZu0XQTxI6a6jwA/hMDD36pP0HBxBOGuHP1hWCebDzMjraiMfWiP9w7hKERFE4j19kocHxIXyocfJA==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/icon": "2.0.5",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/live-region": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/live-region/-/live-region-1.1.6.tgz",
-      "integrity": "sha512-9gPQHXf7oW0jXyT5R/JzyDMfJ3hF70TqhN8bRH4fMyfNr2Se+SjztMBqCrv5FS5rPjcCeua+e0eArpoB3ROuWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/media-query": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/media-query/-/media-query-2.0.4.tgz",
-      "integrity": "sha512-kn6g/L0IFFUHz2v4yiCsBnhg9jUeA7525Z+AWl+BPtvryi7i9J+AJ27y/QAge7vUGy4dwDeFyxOZTs2oZ9/BsA==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/react-env": "1.1.6",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "@chakra-ui/theme": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/menu": {
-      "version": "1.8.12",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/menu/-/menu-1.8.12.tgz",
-      "integrity": "sha512-X/s74VpOReQW4fCRCa21f/VOe++cXhPz2Sh7pDjtaT3zmKjrJwgk1Kw75cXfNX1eke6hf/wZ0FGweu/m7+C3OA==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/clickable": "1.2.6",
-        "@chakra-ui/descendant": "2.1.4",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/popper": "2.4.3",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/transition": "1.4.8",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": "3.x || 4.x || 5.x || 6.x",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/modal": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/modal/-/modal-1.11.1.tgz",
-      "integrity": "sha512-B2BBDonHb04vbPLAWgko1JYBwgW8ZNSLyhTJK+rbrCsRSgazuLTcwq4hdyJqrYNWtaQEfSwpAXqJ7joMZdv59A==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/close-button": "1.2.7",
-        "@chakra-ui/focus-lock": "1.2.6",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/portal": "1.3.10",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/transition": "1.4.8",
-        "@chakra-ui/utils": "1.10.4",
-        "aria-hidden": "^1.1.1",
-        "react-remove-scroll": "2.4.1"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": "3.x || 4.x || 5.x || 6.x",
-        "react": ">=16.8.6",
-        "react-dom": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/modal/node_modules/@types/react": {
-      "version": "17.0.91",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.91.tgz",
-      "integrity": "sha512-xauZca6qMeCU3Moy0KxCM9jtf1vyk6qRYK39Ryf3afUqwgNUjRIGoDdS9BcGWgAMGSg1hvP4XcmlYrM66PtqeA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "^0.16",
-        "csstype": "^3.2.2"
-      }
-    },
-    "node_modules/@chakra-ui/modal/node_modules/csstype": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@chakra-ui/modal/node_modules/react-remove-scroll": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.4.1.tgz",
-      "integrity": "sha512-K7XZySEzOHMTq7dDwcHsZA6Y7/1uX5RsWhRXVYv8rdh+y9Qz2nMwl9RX/Mwnj/j7JstCGmxyfyC0zbVGXYh3mA==",
-      "license": "MIT",
-      "dependencies": {
-        "react-remove-scroll-bar": "^2.1.0",
-        "react-style-singleton": "^2.1.0",
-        "tslib": "^1.0.0",
-        "use-callback-ref": "^1.2.3",
-        "use-sidecar": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=8.5.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0",
-        "react": "^16.8.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@chakra-ui/modal/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
-    },
-    "node_modules/@chakra-ui/number-input": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/number-input/-/number-input-1.4.7.tgz",
-      "integrity": "sha512-LorGRZFMipom8vCUEbLi2s7bTHF2Fgiu766W0jTbzMje+8Z1ZoRQunH9OZWQnxnWQTUfUM2KBW8KwToYh1ojfQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/counter": "1.2.10",
-        "@chakra-ui/form-control": "1.6.0",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/icon": "2.0.5",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/pin-input": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/pin-input/-/pin-input-1.7.11.tgz",
-      "integrity": "sha512-KEVUHHmf22tI4F7gzT9+pHi4E5cCyte6M8rPEwRyuc0kUBo48D8OW0BJwGdESWOKMkQXazDF6Zg4o32t45tbpg==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/descendant": "2.1.4",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/popover": {
-      "version": "1.11.9",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/popover/-/popover-1.11.9.tgz",
-      "integrity": "sha512-hJ1/Lwukox3ryTN7W1wnj+nE44utfLwQYvfUSdatt5dznnh8k0P6Wx7Hmjm1cYffRavBhqzwua/QZDWjJN9N0g==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/close-button": "1.2.7",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/popper": "2.4.3",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": "3.x || 4.x || 5.x || 6.x",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/popper": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/popper/-/popper-2.4.3.tgz",
-      "integrity": "sha512-TGzFnYt3mtIVkIejtYIAu4Ka9DaYLzMR4NgcqI6EtaTvgK7Xep+6RTiY/Nq+ZT3l/eaNUwqHRFoNrDUg1XYasA==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/react-utils": "1.2.3",
-        "@popperjs/core": "^2.9.3"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/portal": {
-      "version": "1.3.10",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/portal/-/portal-1.3.10.tgz",
-      "integrity": "sha512-t2KQ6MXbyf1qFYxWw/bs//CnwD+Clq7mbsP1Y7g+THCz2FvlLlMj45BWocLB30NoNyA8WCS2zyMBszW2/qvDiA==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6",
-        "react-dom": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/progress": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/progress/-/progress-1.2.6.tgz",
-      "integrity": "sha512-thaHRIYTVktgV78vJMNwzfCX+ickhSpn2bun6FtGVUphFx4tjV+ggz+IGohm6AH2hapskoR1mQU2iNZb6BK0hQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/theme-tools": "1.3.6",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/provider": {
-      "version": "1.7.14",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/provider/-/provider-1.7.14.tgz",
-      "integrity": "sha512-FCA33CZy/jFzExglKMioeri8sr9NtDTcNVPnx95ZJiA7WpfFo0xuZ6/fMC4DwIQPkJKbSIZBXYLZ3U10Ntylrw==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/css-reset": "1.1.3",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/portal": "1.3.10",
-        "@chakra-ui/react-env": "1.1.6",
-        "@chakra-ui/system": "1.12.1",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.0.0",
-        "@emotion/styled": "^11.0.0",
-        "react": ">=16.8.6",
-        "react-dom": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/radio": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/radio/-/radio-1.5.1.tgz",
-      "integrity": "sha512-zO5eShz+j68A7935jJ2q5u3brX/bjPEGh9Pj2+bnKbmC9Vva6jEzBSJsAx9n4WbkAzR3xDMGWsbpivFp8X1tJw==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/form-control": "1.6.0",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4",
-        "@chakra-ui/visually-hidden": "1.1.6"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
+        "react": ">=18"
       }
     },
     "node_modules/@chakra-ui/react": {
-      "version": "1.8.9",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-1.8.9.tgz",
-      "integrity": "sha512-NfR5XKVqEWhchFLiWaTWkWeYZJK1SNF2O6sQxFVrX6M+nAgJ3Q9tfMk6/I3II+xc4hXJUcYmUvmw37vT92yMaQ==",
+      "version": "2.10.10",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-2.10.10.tgz",
+      "integrity": "sha512-uahxAfb83/O9fcgBm3ew/nVeQiNgE0uQf8NdQQp3I6u/PCuR2OjSEneV4Ba86W8z50Ppwcxvf9XDk5btYceggQ==",
       "license": "MIT",
       "dependencies": {
-        "@chakra-ui/accordion": "1.4.12",
-        "@chakra-ui/alert": "1.3.7",
-        "@chakra-ui/avatar": "1.3.11",
-        "@chakra-ui/breadcrumb": "1.3.6",
-        "@chakra-ui/button": "1.5.10",
-        "@chakra-ui/checkbox": "1.7.1",
-        "@chakra-ui/close-button": "1.2.7",
-        "@chakra-ui/control-box": "1.1.6",
-        "@chakra-ui/counter": "1.2.10",
-        "@chakra-ui/css-reset": "1.1.3",
-        "@chakra-ui/editable": "1.4.2",
-        "@chakra-ui/form-control": "1.6.0",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/icon": "2.0.5",
-        "@chakra-ui/image": "1.1.10",
-        "@chakra-ui/input": "1.4.6",
-        "@chakra-ui/layout": "1.8.0",
-        "@chakra-ui/live-region": "1.1.6",
-        "@chakra-ui/media-query": "2.0.4",
-        "@chakra-ui/menu": "1.8.12",
-        "@chakra-ui/modal": "1.11.1",
-        "@chakra-ui/number-input": "1.4.7",
-        "@chakra-ui/pin-input": "1.7.11",
-        "@chakra-ui/popover": "1.11.9",
-        "@chakra-ui/popper": "2.4.3",
-        "@chakra-ui/portal": "1.3.10",
-        "@chakra-ui/progress": "1.2.6",
-        "@chakra-ui/provider": "1.7.14",
-        "@chakra-ui/radio": "1.5.1",
-        "@chakra-ui/react-env": "1.1.6",
-        "@chakra-ui/select": "1.2.11",
-        "@chakra-ui/skeleton": "1.2.14",
-        "@chakra-ui/slider": "1.5.11",
-        "@chakra-ui/spinner": "1.2.6",
-        "@chakra-ui/stat": "1.2.7",
-        "@chakra-ui/switch": "1.3.10",
-        "@chakra-ui/system": "1.12.1",
-        "@chakra-ui/table": "1.3.6",
-        "@chakra-ui/tabs": "1.6.11",
-        "@chakra-ui/tag": "1.2.7",
-        "@chakra-ui/textarea": "1.2.11",
-        "@chakra-ui/theme": "1.14.1",
-        "@chakra-ui/toast": "1.5.9",
-        "@chakra-ui/tooltip": "1.5.1",
-        "@chakra-ui/transition": "1.4.8",
-        "@chakra-ui/utils": "1.10.4",
-        "@chakra-ui/visually-hidden": "1.1.6"
+        "@chakra-ui/hooks": "2.4.6",
+        "@chakra-ui/styled-system": "2.12.5",
+        "@chakra-ui/theme": "3.4.10",
+        "@chakra-ui/utils": "2.2.6",
+        "@popperjs/core": "^2.11.8",
+        "@zag-js/focus-visible": "^0.31.1",
+        "aria-hidden": "^1.2.3",
+        "react-fast-compare": "3.2.2",
+        "react-focus-lock": "^2.9.6",
+        "react-remove-scroll": "^2.5.7"
       },
       "peerDependencies": {
-        "@emotion/react": "^11.0.0",
-        "@emotion/styled": "^11.0.0",
-        "framer-motion": "3.x || 4.x || 5.x || 6.x",
-        "react": ">=16.8.6",
-        "react-dom": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/react-env": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-env/-/react-env-1.1.6.tgz",
-      "integrity": "sha512-L90LNvCfe04FTkN9OPok/o2e60zLJNBH8Im/5dUHvqy7dXLXok8ZDad5vEL46XmGbhe7O8fbxhG6FmAYdcCHrQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/react-utils": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react-utils/-/react-utils-1.2.3.tgz",
-      "integrity": "sha512-r8pUwCVVB7UPhb0AiRa9ZzSp4xkMz64yIeJ4O4aGy4WMw7TRH4j4QkbkE1YC9tQitrXrliOlvx4WWJR4VyiGpw==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/utils": "^1.10.4"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/select": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/select/-/select-1.2.11.tgz",
-      "integrity": "sha512-6Tis1+ZrRjQeWhQfziQn3ZdPphV5ccafpZOhiPdTcM2J1XcXOlII+9rHxvaW+jx7zQ5ly5o8kd7iXzalDgl5wA==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/form-control": "1.6.0",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/skeleton": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/skeleton/-/skeleton-1.2.14.tgz",
-      "integrity": "sha512-R0v4DfQ2yjXCJf9SzhTmDb2PLx5//LxsRbjjgRa8qJCR4MZaGswPrekp4dP8YjY8aEYzuZbvHU12T3vqZBk2GA==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/media-query": "2.0.4",
-        "@chakra-ui/system": "1.12.1",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/theme": ">=1.0.0",
-        "@emotion/react": "^11.0.0",
-        "@emotion/styled": "^11.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/slider": {
-      "version": "1.5.11",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/slider/-/slider-1.5.11.tgz",
-      "integrity": "sha512-THkGU2BsA6XMosXcEVQkWVRftqUIAKCb+y4iEpR3C2ztqL7Fl/CbIGwyr5majhPhKc275rb8dfxwp8R0L0ZIiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/spinner": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/spinner/-/spinner-1.2.6.tgz",
-      "integrity": "sha512-GoUCccN120fGRVgUtfuwcEjeoaxffB+XsgpxX7jhWloXf8b6lkqm68bsxX4Ybb2vGN1fANI98/45JmrnddZO/A==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/utils": "1.10.4",
-        "@chakra-ui/visually-hidden": "1.1.6"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/stat": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/stat/-/stat-1.2.7.tgz",
-      "integrity": "sha512-m76jumFW1N+mCG4ytrUz9Mh09nZtS4OQcADEvOslfdI5StwwuzasTA1tueaelPzdhBioMwFUWL05Fr1fXbPJ/Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/icon": "2.0.5",
-        "@chakra-ui/utils": "1.10.4",
-        "@chakra-ui/visually-hidden": "1.1.6"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
+        "@emotion/react": ">=11",
+        "@emotion/styled": ">=11",
+        "framer-motion": ">=4.0.0",
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/@chakra-ui/styled-system": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-1.19.0.tgz",
-      "integrity": "sha512-z+bMfWs6jQGkpgarge1kmk78DuDhJIXRUMyRqZ3+CiIkze88bIIsww6mV2i8tEfUfTAvALeMnlYZ1DYsHsTTJw==",
+      "version": "2.12.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.12.5.tgz",
+      "integrity": "sha512-sy39LJWnOvGcOHYBXQxT3bC5zj+R7GVUgxzkkoqx+auV5KVKOOE5aZD+POsciWEt86bqdEa+LpFm+E5pcdbkyg==",
       "license": "MIT",
       "dependencies": {
-        "@chakra-ui/utils": "1.10.4",
-        "csstype": "3.0.9"
-      }
-    },
-    "node_modules/@chakra-ui/switch": {
-      "version": "1.3.10",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/switch/-/switch-1.3.10.tgz",
-      "integrity": "sha512-V6qDLY6oECCbPyu7alWWOAhSBI4+SAuT6XW/zEQbelkwuUOiGO1ax67rTXOmZ59A2AaV1gqQFxDh8AcbvwO5XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/checkbox": "1.7.1",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": "3.x || 4.x || 5.x || 6.x",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/system": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/system/-/system-1.12.1.tgz",
-      "integrity": "sha512-Rp09/rMuPA3hF38OJxeQciGO9N0Ie1GxwHRAw1AFA/TY3fVyK9pNI5oN+J/1cAxq7v9yKdIr1YfnruJTI9xfEg==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/color-mode": "1.4.8",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/styled-system": "1.19.0",
-        "@chakra-ui/utils": "1.10.4",
-        "react-fast-compare": "3.2.0"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.0.0",
-        "@emotion/styled": "^11.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/table": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/table/-/table-1.3.6.tgz",
-      "integrity": "sha512-7agZAgAeDFKviqStvixqnLAH54+setzhx67EztioZTr5Xu+6hQ4rotfJbu8L4i587pcbNg98kCEXEkidjw0XRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/tabs": {
-      "version": "1.6.11",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/tabs/-/tabs-1.6.11.tgz",
-      "integrity": "sha512-hGs2REEVVWyfgs+qEkPiUsNnqwv3QwXfKYyXaMnGS7CCkGgUiEvIO7n9968/KGnGbM4GuEHX+BxG2suIUf24yg==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/clickable": "1.2.6",
-        "@chakra-ui/descendant": "2.1.4",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/tag": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/tag/-/tag-1.2.7.tgz",
-      "integrity": "sha512-RKrKOol4i/CnpFfo3T9LMm1abaqM+5Bs0soQLbo1iJBbBACY09sWXrQYvveQ2GYzU/OrAUloHqqmKjyVGOlNtg==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/icon": "2.0.5",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/textarea": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/textarea/-/textarea-1.2.11.tgz",
-      "integrity": "sha512-RDWbMyC87/AFRX98EnVum5eig/7hhcvS1BrqW5lvmTgrpr7KVr80Dfa8hUj58Iq37Z7AqZijDPkBn/zg7bPdIg==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/form-control": "1.6.0",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
+        "@chakra-ui/utils": "2.2.6",
+        "csstype": "^3.1.2"
       }
     },
     "node_modules/@chakra-ui/theme": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/theme/-/theme-1.14.1.tgz",
-      "integrity": "sha512-VeNZi+zD3yDwzvZm234Cy3vnalCzQ+dhAgpHdIYzGO1CYO8DPa+ROcQ70rUueL7dSvUz15KOiGTw6DAl7LXlGA==",
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme/-/theme-3.4.10.tgz",
+      "integrity": "sha512-iSz8dsSJqMUkABy6CO4ArPnaSkFzY+Y0z4z3sg2COyvuo0JoVXEOFvDhNsGPAa+5MT8YZEpM2aKS7dE0ZZQ2aA==",
       "license": "MIT",
       "dependencies": {
-        "@chakra-ui/anatomy": "1.3.0",
-        "@chakra-ui/theme-tools": "1.3.6",
-        "@chakra-ui/utils": "1.10.4"
+        "@chakra-ui/anatomy": "2.3.6",
+        "@chakra-ui/theme-tools": "2.2.10",
+        "@chakra-ui/utils": "2.2.6"
       },
       "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0"
+        "@chakra-ui/styled-system": ">=2.8.0"
       }
     },
     "node_modules/@chakra-ui/theme-tools": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-tools/-/theme-tools-1.3.6.tgz",
-      "integrity": "sha512-Wxz3XSJhPCU6OwCHEyH44EegEDQHwvlsx+KDkUDGevOjUU88YuNqOVkKtgTpgMLNQcsrYZ93oPWZUJqqCVNRew==",
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-tools/-/theme-tools-2.2.10.tgz",
+      "integrity": "sha512-VX+zOwa1mIhvjD25FEDfh7T/mnwk03p0WQEWm5RYDOM20ePpwj4QMFwU/1zXiYwc2vZTouYLDmVBF3nJjmiPzw==",
       "license": "MIT",
       "dependencies": {
-        "@chakra-ui/utils": "1.10.4",
-        "@ctrl/tinycolor": "^3.4.0"
+        "@chakra-ui/anatomy": "2.3.6",
+        "@chakra-ui/utils": "2.2.6",
+        "color2k": "^2.0.2"
       },
       "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0"
-      }
-    },
-    "node_modules/@chakra-ui/toast": {
-      "version": "1.5.9",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/toast/-/toast-1.5.9.tgz",
-      "integrity": "sha512-rns04bGdMcG7Ijg45L+PfuEW4rCd0Ycraix4EJQhcl9RXI18G9sphmlp9feidhZAkI6Ukafq1YvyvkBfkKnIzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/alert": "1.3.7",
-        "@chakra-ui/close-button": "1.2.7",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/theme": "1.14.1",
-        "@chakra-ui/transition": "1.4.8",
-        "@chakra-ui/utils": "1.10.4",
-        "@reach/alert": "0.13.2"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": "3.x || 4.x || 5.x || 6.x",
-        "react": ">=16.8.6",
-        "react-dom": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/toast/node_modules/@reach/alert": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/@reach/alert/-/alert-0.13.2.tgz",
-      "integrity": "sha512-LDz83AXCrClyq/MWe+0vaZfHp1Ytqn+kgL5VxG7rirUvmluWaj/snxzfNPWn0Ma4K2YENmXXRC/iHt5X95SqIg==",
-      "license": "MIT",
-      "dependencies": {
-        "@reach/utils": "0.13.2",
-        "@reach/visually-hidden": "0.13.2",
-        "prop-types": "^15.7.2",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
-    "node_modules/@chakra-ui/tooltip": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/tooltip/-/tooltip-1.5.1.tgz",
-      "integrity": "sha512-EUAlDdlCBt63VpEVtj/RkFjHQVN/xA9gEAumngQdi1Sp+OXPYCBM9GwSY0NwrM1RfKBnhPSH9wz7FwredJWeaw==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/popper": "2.4.3",
-        "@chakra-ui/portal": "1.3.10",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4",
-        "@chakra-ui/visually-hidden": "1.1.6"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": "3.x || 4.x || 5.x || 6.x",
-        "react": ">=16.8.6",
-        "react-dom": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/transition": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/transition/-/transition-1.4.8.tgz",
-      "integrity": "sha512-5uc8LEuCH7+0h++wqAav/EktTHOjbLDSTXQlU9fzPIlNNgyf2eXrHVN2AGMGKiMR9Z4gS7umQjZ54r0w/mZ/Fw==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "framer-motion": "3.x || 4.x || 5.x || 6.x",
-        "react": ">=16.8.6"
+        "@chakra-ui/styled-system": ">=2.0.0"
       }
     },
     "node_modules/@chakra-ui/utils": {
-      "version": "1.10.4",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.10.4.tgz",
-      "integrity": "sha512-AM91VQQxw8F4F1WDA28mqKY6NFIOuzc2Ekkna88imy2OiqqmYH0xkq8J16L2qj4cLiLozpYqba3C79pWioy6FA==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-2.2.6.tgz",
+      "integrity": "sha512-xTnQaHHAplUsQb87/0aZt85fFECqee7B35Ib3RNHKvHSNHS2Kz7YkQiof8xYSBQqKCdrsEFeg+ngS2ViCXiK7w==",
       "license": "MIT",
       "dependencies": {
-        "@types/lodash.mergewith": "4.6.6",
-        "css-box-model": "1.2.1",
-        "framesync": "5.3.0",
+        "@types/lodash.mergewith": "4.6.9",
         "lodash.mergewith": "4.6.2"
-      }
-    },
-    "node_modules/@chakra-ui/visually-hidden": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/visually-hidden/-/visually-hidden-1.1.6.tgz",
-      "integrity": "sha512-Xzy5bA0UA+IyMgwJizQYSEdgz8cC/tHdmFB3CniXzmpKTSK8mJddeEBl+cGbXHBzxEUhH7xF1eaS41O+0ezWEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/utils": "1.10.4"
       },
       "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@ctrl/tinycolor": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz",
-      "integrity": "sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1189,7 +299,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
       "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.16.7",
         "@babel/runtime": "^7.18.3",
@@ -1209,7 +318,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
       "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.9.0",
         "@emotion/sheet": "^1.4.0",
@@ -1222,15 +330,13 @@
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
       "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
       "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.9.0"
       }
@@ -1239,15 +345,13 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
       "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@emotion/react": {
       "version": "11.14.0",
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1272,7 +376,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
       "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/hash": "^0.9.2",
         "@emotion/memoize": "^0.9.0",
@@ -1285,15 +388,13 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
       "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@emotion/styled": {
       "version": "11.14.1",
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1316,15 +417,13 @@
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
       "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
       "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": ">=16.8.0"
       }
@@ -1333,22 +432,19 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
       "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@emotion/weak-memoize": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
       "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -1359,7 +455,6 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1368,88 +463,16 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@motionone/animation": {
-      "version": "10.18.0",
-      "resolved": "https://registry.npmjs.org/@motionone/animation/-/animation-10.18.0.tgz",
-      "integrity": "sha512-9z2p5GFGCm0gBsZbi8rVMOAJCtw1WqBTIPw3ozk06gDvZInBPIsQcHgYogEJ4yuHJ+akuW8g1SEIOpTOvYs8hw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@motionone/easing": "^10.18.0",
-        "@motionone/types": "^10.17.1",
-        "@motionone/utils": "^10.18.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@motionone/dom": {
-      "version": "10.12.0",
-      "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.12.0.tgz",
-      "integrity": "sha512-UdPTtLMAktHiqV0atOczNYyDd/d8Cf5fFsd1tua03PqTwwCe/6lwhLSQ8a7TbnQ5SN0gm44N1slBfj+ORIhrqw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@motionone/animation": "^10.12.0",
-        "@motionone/generators": "^10.12.0",
-        "@motionone/types": "^10.12.0",
-        "@motionone/utils": "^10.12.0",
-        "hey-listen": "^1.0.8",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@motionone/easing": {
-      "version": "10.18.0",
-      "resolved": "https://registry.npmjs.org/@motionone/easing/-/easing-10.18.0.tgz",
-      "integrity": "sha512-VcjByo7XpdLS4o9T8t99JtgxkdMcNWD3yHU/n6CLEz3bkmKDRZyYQ/wmSf6daum8ZXqfUAgFeCZSpJZIMxaCzg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@motionone/utils": "^10.18.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@motionone/generators": {
-      "version": "10.18.0",
-      "resolved": "https://registry.npmjs.org/@motionone/generators/-/generators-10.18.0.tgz",
-      "integrity": "sha512-+qfkC2DtkDj4tHPu+AFKVfR/C30O1vYdvsGYaR13W/1cczPrrcjdvYCj0VLFuRMN+lP1xvpNZHCRNM4fBzn1jg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@motionone/types": "^10.17.1",
-        "@motionone/utils": "^10.18.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@motionone/types": {
-      "version": "10.17.1",
-      "resolved": "https://registry.npmjs.org/@motionone/types/-/types-10.17.1.tgz",
-      "integrity": "sha512-KaC4kgiODDz8hswCrS0btrVrzyU2CSQKO7Ps90ibBVSQmjkrt2teqta6/sOG59v7+dPnKMAg13jyqtMKV2yJ7A==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@motionone/utils": {
-      "version": "10.18.0",
-      "resolved": "https://registry.npmjs.org/@motionone/utils/-/utils-10.18.0.tgz",
-      "integrity": "sha512-3XVF7sgyTSI2KWvTf6uLlBJ5iAgRgmvp3bpuOiQJvInd4nZ19ET8lX5unn30SlmRH7hXbBbH+Gxd0m0klJ3Xtw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@motionone/types": "^10.17.1",
-        "hey-listen": "^1.0.8",
-        "tslib": "^2.3.1"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -1489,35 +512,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
-      }
-    },
-    "node_modules/@reach/utils": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.13.2.tgz",
-      "integrity": "sha512-3ir6cN60zvUrwjOJu7C6jec/samqAeyAB12ZADK+qjnmQPdzSYldrFWwDVV5H0WkhbYXR3uh+eImu13hCetNPQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/warning": "^3.0.0",
-        "tslib": "^2.1.0",
-        "warning": "^4.0.3"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
-    "node_modules/@reach/visually-hidden": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/@reach/visually-hidden/-/visually-hidden-0.13.2.tgz",
-      "integrity": "sha512-sPZwNS0/duOuG0mYwE5DmgEAzW9VhgU3aIt1+mrfT/xiT9Cdncqke+kRBQgU708q/Ttm9tWsoHni03nn/SuPTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "prop-types": "^15.7.2",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1778,9 +772,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.7",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
-      "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1802,9 +796,9 @@
       "license": "MIT"
     },
     "node_modules/@types/lodash.mergewith": {
-      "version": "4.6.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.mergewith/-/lodash.mergewith-4.6.6.tgz",
-      "integrity": "sha512-RY/8IaVENjG19rxTZu9Nukqh0W2UrYgmBj5sdns4hWRZaV8PqR7wIKHFKzvOTjo4zVRV7sVI+yFhAJql12Kfqg==",
+      "version": "4.6.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.mergewith/-/lodash.mergewith-4.6.9.tgz",
+      "integrity": "sha512-fgkoCAOF47K7sxrQ7Mlud2TH023itugZs2bUg8h/KzT+BnZNrR2jAOmaokbLunHNnobXVWOezAeNn/lZqwxkcw==",
       "license": "MIT",
       "dependencies": {
         "@types/lodash": "*"
@@ -1814,8 +808,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -1825,9 +818,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "18.3.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
-      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -1845,35 +838,14 @@
         "@types/react": "^18.0.0"
       }
     },
-    "node_modules/@types/react/node_modules/csstype": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/scheduler": {
-      "version": "0.16.8",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
-      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@types/warning": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.4.tgz",
-      "integrity": "sha512-CqN8MnISMwQbLJXO3doBAV4Yw9hx9/Pyr2rZ78+NfaCnhyRA/nKrpyk6E7mKw17ZOaQdLpK9GiUjrqLzBlN3sg==",
-      "license": "MIT"
-    },
     "node_modules/@vitejs/plugin-react": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
-      "integrity": "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
+      "integrity": "sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rolldown/pluginutils": "1.0.0-rc.7"
+        "@rolldown/pluginutils": "^1.0.1"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -1890,6 +862,27 @@
         "babel-plugin-react-compiler": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@zag-js/dom-query": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-0.31.1.tgz",
+      "integrity": "sha512-oiuohEXAXhBxpzzNm9k2VHGEOLC1SXlXSbRPcfBZ9so5NRQUA++zCE7cyQJqGLTZR0t3itFLlZqDbYEXRrefwg==",
+      "license": "MIT"
+    },
+    "node_modules/@zag-js/element-size": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/element-size/-/element-size-0.31.1.tgz",
+      "integrity": "sha512-4T3yvn5NqqAjhlP326Fv+w9RqMIBbNN9H72g5q2ohwzhSgSfZzrKtjL4rs9axY/cw9UfMfXjRjEE98e5CMq7WQ==",
+      "license": "MIT"
+    },
+    "node_modules/@zag-js/focus-visible": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-0.31.1.tgz",
+      "integrity": "sha512-dbLksz7FEwyFoANbpIlNnd3bVm0clQSUsnP8yUVQucStZPsuWjCrhL2jlAbGNrTrahX96ntUMXHb/sM68TibFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "0.31.1"
       }
     },
     "node_modules/aria-hidden": {
@@ -1909,7 +902,6 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
       "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "cosmiconfig": "^7.0.0",
@@ -1925,28 +917,26 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
     },
-    "node_modules/compute-scroll-into-view": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.14.tgz",
-      "integrity": "sha512-mKDjINe3tc6hGelUMNDzuhorIUZ7kS7BwyY0r2wQd2HOH2tRuJykiC06iSEX8y1TuhNzvz4GcJnK16mM2J1NMQ==",
+    "node_modules/color2k": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.4.tgz",
+      "integrity": "sha512-OXAPGFRNeLFnUfqDtloYdxkwsJoIdXe28+bjbpJiPqyei2HPa3VHmMCWa0Qe62+U4Ftf9Hj7hRssOkxz7WiWbg==",
       "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/copy-to-clipboard": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
-      "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
       "license": "MIT",
       "dependencies": {
         "toggle-selection": "^1.0.6"
@@ -1957,7 +947,6 @@
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
       "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
@@ -1974,24 +963,14 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
       "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">= 6"
       }
     },
-    "node_modules/css-box-model": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
-      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
-      "license": "MIT",
-      "dependencies": {
-        "tiny-invariant": "^1.0.6"
-      }
-    },
     "node_modules/csstype": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.9.tgz",
-      "integrity": "sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -1999,7 +978,6 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -2033,7 +1011,6 @@
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
       "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
@@ -2043,7 +1020,6 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -2053,7 +1029,6 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2083,13 +1058,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
       "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/focus-lock": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.9.2.tgz",
-      "integrity": "sha512-YtHxjX7a0IC0ZACL5wsX8QdncXofWpGPNoVMuI/nZUrPGp6LmNI6+D5j0pPj+v8Kw5EpweA+T5yImK0rnWf7oQ==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.3.6.tgz",
+      "integrity": "sha512-Ik/6OCk9RQQ0T5Xw+hKNLWrjSMtv51dD4GRmJjbD5a58TIEpI5a5iXagKVl3Z5UuyslMCA8Xwnu76jQob62Yhg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
@@ -2099,64 +1073,46 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-6.5.1.tgz",
-      "integrity": "sha512-o1BGqqposwi7cgDrtg0dNONhkmPsUFDaLcKXigzuTFC5x58mE8iyTazxSudFzmT6MEyJKfjjU8ItoMe3W+3fiw==",
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@motionone/dom": "10.12.0",
-        "framesync": "6.0.1",
-        "hey-listen": "^1.0.8",
-        "popmotion": "11.0.3",
-        "style-value-types": "5.0.0",
-        "tslib": "^2.1.0"
-      },
-      "optionalDependencies": {
-        "@emotion/is-prop-valid": "^0.8.2"
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
       },
       "peerDependencies": {
-        "react": ">=16.8 || ^17.0.0 || ^18.0.0",
-        "react-dom": ">=16.8 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/framer-motion/node_modules/@emotion/is-prop-valid": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
-      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emotion/memoize": "0.7.4"
-      }
-    },
-    "node_modules/framer-motion/node_modules/@emotion/memoize": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/framer-motion/node_modules/framesync": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
-      "integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.1.0"
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/framesync": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/framesync/-/framesync-5.3.0.tgz",
-      "integrity": "sha512-oc5m68HDO/tuK2blj7ZcdEBRx3p1PjrgHazL8GYEpvULhrtGIFbQArN6cQS2QhW8mitffaB+VYzMjDqBxxQeoA==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.1.2.tgz",
+      "integrity": "sha512-jBTqhX6KaQVDyus8muwZbBeGGP0XgujBRbQ7gM7BRdS3CadCZIHiawyzYLnafYcvZIh5j8WE7cxZKFn7dXhu9g==",
       "license": "MIT",
       "dependencies": {
-        "tslib": "^2.1.0"
+        "tslib": "2.4.0"
       }
+    },
+    "node_modules/framesync/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "license": "0BSD"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -2178,7 +1134,6 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -2193,11 +1148,10 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -2205,19 +1159,11 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hey-listen": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
-      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "react-is": "^16.7.0"
       }
@@ -2227,7 +1173,6 @@
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -2243,17 +1188,15 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2273,7 +1216,6 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -2285,8 +1227,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -2553,8 +1494,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.mergewith": {
       "version": "4.6.2",
@@ -2574,17 +1514,31 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -2614,7 +1568,6 @@
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -2627,7 +1580,6 @@
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -2645,15 +1597,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2677,33 +1627,10 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/popmotion": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.3.tgz",
-      "integrity": "sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "framesync": "6.0.1",
-        "hey-listen": "^1.0.8",
-        "style-value-types": "5.0.0",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/popmotion/node_modules/framesync": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
-      "integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "dev": true,
       "funding": [
         {
@@ -2778,10 +1705,33 @@
       }
     },
     "node_modules/react-fast-compare": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
-      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
       "license": "MIT"
+    },
+    "node_modules/react-focus-lock": {
+      "version": "2.13.7",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.13.7.tgz",
+      "integrity": "sha512-20lpZHEQrXPb+pp1tzd4ULL6DyO5D2KnR0G69tTDdydrmNhU7pdFmbQUYVyHUgp+xN29IuFR0PVuhOmvaZL9Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "focus-lock": "^1.3.6",
+        "prop-types": "^15.6.2",
+        "react-clientside-effect": "^1.2.7",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-is": {
       "version": "16.13.1",
@@ -2800,6 +1750,31 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19",
         "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-remove-scroll-bar": {
@@ -2851,7 +1826,6 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
       "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
@@ -2873,7 +1847,6 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -2912,13 +1885,6 @@
         "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
-    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
-      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -2933,7 +1899,6 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2948,42 +1913,23 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/style-value-types": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.0.0.tgz",
-      "integrity": "sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "hey-listen": "^1.0.8",
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/stylis": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
       "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/tiny-invariant": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
@@ -3072,16 +2018,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -3149,13 +2095,22 @@
         }
       }
     },
-    "node_modules/warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     }
   }

--- a/client/package.json
+++ b/client/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@chakra-ui/layout": "^1.8.0",
-    "@chakra-ui/react": "^1.8.9",
-    "@chakra-ui/system": "^1.12.1",
+    "@chakra-ui/react": "^2.8.2",
+    "@emotion/react": "^11.13.0",
+    "@emotion/styled": "^11.13.0",
+    "framer-motion": "^11.5.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-plaid-link": "^4.1.1"
@@ -22,27 +23,5 @@
     "start": "vite",
     "build": "vite build",
     "preview": "vite preview"
-  },
-  "overrides": {
-    "react-focus-lock": {
-      "react": "$react",
-      "react-dom": "$react-dom"
-    },
-    "react-remove-scroll": {
-      "react": "$react",
-      "react-dom": "$react-dom"
-    },
-    "@reach/alert": {
-      "react": "$react",
-      "react-dom": "$react-dom"
-    },
-    "@reach/utils": {
-      "react": "$react",
-      "react-dom": "$react-dom"
-    },
-    "@reach/visually-hidden": {
-      "react": "$react",
-      "react-dom": "$react-dom"
-    }
   }
 }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,12 @@
 import { useState } from "react";
-import { ChakraProvider, Text } from "@chakra-ui/react";
-import { Box, Flex, Heading, VStack } from "@chakra-ui/layout";
+import {
+  ChakraProvider,
+  Text,
+  Box,
+  Flex,
+  Heading,
+  VStack,
+} from "@chakra-ui/react";
 import { UserContext, PlaidConnectStatus } from "./components/UserContext";
 import UserStatus from "./components/UserStatus";
 import DebugPanel from "./components/DebugPanel";

--- a/client/src/components/BankIncome.tsx
+++ b/client/src/components/BankIncome.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useContext, useEffect, useState } from "react";
 import { UserContext } from "./UserContext";
 import LinkLoader, { IncomeType } from "./LinkLoader";
-import { Box, Flex, Heading, VStack } from "@chakra-ui/layout";
+import { Box, Flex, Heading, VStack } from "@chakra-ui/react";
 
 interface BankData {
   bank_name: string;

--- a/client/src/components/Liabilities.tsx
+++ b/client/src/components/Liabilities.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Heading, VStack } from "@chakra-ui/layout";
+import { Box, Flex, Heading, VStack } from "@chakra-ui/react";
 import { useCallback, useEffect, useState } from "react";
 
 enum LiabilityType {
@@ -77,6 +77,10 @@ const Liabilities = () => {
 
 const normalizeLiabilityData = (data: any) => {
   // A little bit of work to merge these...
+  // Bail out if we got back an error body instead of liabilities data.
+  if (data?.liabilities == null || data?.accounts == null) {
+    return [];
+  }
   type CreditType = {
     account_id: string;
     aprs: {

--- a/client/src/components/LinkLoader.tsx
+++ b/client/src/components/LinkLoader.tsx
@@ -1,7 +1,7 @@
 import { useContext, useState } from "react";
 import { UserContext, PlaidConnectStatus } from "./UserContext";
 import LaunchLink from "./LinkLauncher";
-import { Button } from "@chakra-ui/button";
+import { Button } from "@chakra-ui/react";
 
 export enum IncomeType {
   Bank = "bank",
@@ -27,7 +27,9 @@ const LinkLoader = (props: Props) => {
 
   const loadAndLaunchLink = async () => {
     const linkToken = await fetchLinkToken();
-    setLinkToken(linkToken);
+    if (linkToken) {
+      setLinkToken(linkToken);
+    }
   };
 
   const linkSuccess = async (public_token: String) => {
@@ -85,16 +87,15 @@ const LinkLoader = (props: Props) => {
       headers: { "Content-type": "application/json" },
       body: messageBody,
     });
-    if (response.status === 500) {
+    if (!response.ok) {
       alert(
         "We received an error trying to create a link token. Please make sure you've followed all the setup steps in the readme file, and that your account is activated for income verification."
       );
-    } else {
-      const data = await response.json();
-
-      console.log(`Got back link token ${data.link_token}`);
-      return data.link_token;
+      return;
     }
+    const data = await response.json();
+    console.log(`Got back link token ${data.link_token}`);
+    return data.link_token;
   };
 
   return (

--- a/client/src/components/PayrollIncome.tsx
+++ b/client/src/components/PayrollIncome.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useContext, useEffect, useState } from "react";
 import { UserContext } from "./UserContext";
 import LinkLoader, { IncomeType } from "./LinkLoader";
-import { Badge, Box, Flex, Heading, VStack } from "@chakra-ui/layout";
+import { Badge, Box, Flex, Heading, VStack } from "@chakra-ui/react";
 
 interface PayrollData {
   employer: string;
@@ -28,7 +28,7 @@ const PayrollIncome = () => {
     console.log("Payroll Income: ", data);
     // `items` is an array of objects, each of which contains an array of
     // `payroll` income objects, each of which contains an array of `pay_stubs`
-    const allPayrollIncome = data.items
+    const allPayrollIncome = (data.items ?? [])
       .filter(
         (item: any) => item.status.processing_status === "PROCESSING_COMPLETE"
       )

--- a/client/src/components/UserStatus.tsx
+++ b/client/src/components/UserStatus.tsx
@@ -4,8 +4,7 @@ import PayrollIncome from "./PayrollIncome";
 import Liabilities from "./Liabilities";
 import LinkLoader, { IncomeType } from "./LinkLoader";
 import { UserContext, PlaidConnectStatus } from "./UserContext";
-import { Flex, Heading, Spacer, VStack } from "@chakra-ui/layout";
-import { Text } from "@chakra-ui/react";
+import { Flex, Heading, Spacer, VStack, Text } from "@chakra-ui/react";
 
 /**
  * This object queries the server to find out if the user has connected their

--- a/server/.env.template
+++ b/server/.env.template
@@ -5,8 +5,8 @@ PLAID_SECRET=
 
 # Use 'sandbox' to test with fake credentials in Plaid's Sandbox environment
 # Use 'production' to to use real data
-# When you switch environments, you'll need to re-write user_data.json with 
-# user_data_orig.json, or your application won't work.
+# When you switch environments, you'll need to reset user_data.json by
+# re-copying user_data.json.template, or your application won't work.
 PLAID_ENV=sandbox
 
 # If you want to see incoming webhooks -- particularly relevant when 

--- a/server/server.js
+++ b/server/server.js
@@ -23,10 +23,6 @@ const app = express();
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json());
 
-const server = app.listen(APP_PORT, function () {
-  console.log(`Server is up and running at http://localhost:${APP_PORT}/`);
-});
-
 // Set up the Plaid client
 const plaidConfig = new Configuration({
   basePath: PlaidEnvironments[process.env.PLAID_ENV],
@@ -83,7 +79,19 @@ let userRecord;
     userRecord[FIELD_PLAID_WEBHOOK_USER_ID] = null;
   }
   // Let's make sure we have a user token created at startup
-  await fetchOrCreateUserToken();
+  try {
+    await fetchOrCreateUserToken();
+  } catch (error) {
+    console.error(
+      "Couldn't create a user token at startup. Double-check your PLAID_CLIENT_ID / PLAID_SECRET, and note that accounts created on or after 2025-12-10 must be enabled for user tokens by Plaid support.",
+      error
+    );
+  }
+  // Start listening only once userRecord is populated, so we never handle a
+  // request against an undefined userRecord.
+  app.listen(APP_PORT, function () {
+    console.log(`Server is up and running at http://localhost:${APP_PORT}/`);
+  });
 })();
 
 /**
@@ -144,7 +152,6 @@ app.get("/appServer/get_user_info", async (req, res, next) => {
 });
 
 const basicLinkTokenObject = {
-  user: { client_user_id: "testUser" },
   client_name: "Todd's Hoverboards",
   language: "en",
   products: [],
@@ -158,6 +165,9 @@ const basicLinkTokenObject = {
 app.post("/appServer/generate_link_token", async (req, res, next) => {
   try {
     let response;
+    // Use the same stable, non-PII client_user_id we created the Plaid user
+    // with, per Plaid's Link token guidance.
+    const clientUserId = await getLazyUserID();
     if (req.body.income === true) {
       const userToken = await fetchOrCreateUserToken();
       console.log(`User token returned: ${userToken}`);
@@ -171,6 +181,7 @@ app.post("/appServer/generate_link_token", async (req, res, next) => {
 
       const newIncomeTokenObject = {
         ...basicLinkTokenObject,
+        user: { client_user_id: clientUserId },
         products: ["income_verification"],
         user_token: userToken,
         webhook: webhookUrl,
@@ -183,6 +194,7 @@ app.post("/appServer/generate_link_token", async (req, res, next) => {
     } else {
       const newLiabilitiesTokenObject = {
         ...basicLinkTokenObject,
+        user: { client_user_id: clientUserId },
         products: ["liabilities"],
         webhook: webhookUrl,
       };


### PR DESCRIPTION
Several issues could crash the sample out of the box or diverged from Plaid's Link guidance. This fixes them:

- Start the server listening only after `userRecord` is initialized, so a request arriving during startup no longer dereferences an undefined record.
- Catch a failed `/user/create` at startup (e.g. an account not yet enabled for user tokens) instead of letting it surface as an unhandled promise rejection.
- Send the app's stable, non-PII per-user `client_user_id` (the same one passed to `/user/create`) on link tokens instead of a hardcoded `"testUser"`, per Plaid's Link token guidance.
- Treat any non-2xx link-token response as an error rather than only HTTP 500, so a misconfigured setup shows the alert instead of silently failing to open Link.
- Guard `PayrollIncome` and `Liabilities` against an API error body so they no longer throw while rendering (matching the existing pattern in `BankIncome`).
- Point the `.env.template` reset instruction at `user_data.json.template`; the referenced `user_data_orig.json` does not exist in the repo.
- Upgrade Chakra UI v1 → v2 so the client typechecks under React 18 (v1 produced a `TS2590` error against the React 18 types). Components are unchanged apart from import paths, and the now-obsolete `overrides` block is removed.