### PR TITLE
Upgrade react-plaid-link to 5.0.0

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -14,7 +14,7 @@
         "framer-motion": "^11.5.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-plaid-link": "^4.1.1"
+        "react-plaid-link": "^5.0.0"
       },
       "devDependencies": {
         "@types/react": "^18.3.28",
@@ -1740,9 +1740,9 @@
       "license": "MIT"
     },
     "node_modules/react-plaid-link": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/react-plaid-link/-/react-plaid-link-4.1.1.tgz",
-      "integrity": "sha512-xzAYWQIT/gk+u6lwFAMEZ20f9+AUsCwVyfm64/iudMsyuWANta4wm3Jb7N+APSwuKIR9VUlTkYDhPjLamIGcPA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-plaid-link/-/react-plaid-link-5.0.0.tgz",
+      "integrity": "sha512-DZ/6C7hf+xhEIG9ElCqjk1lty/z+y+wQuV/A29EUx4fxiPLPe7CXN811C3MrCzI7grV45LD7NRS0Do0ma8KIBg==",
       "license": "MIT",
       "dependencies": {
         "prop-types": "^15.7.2"

--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,7 @@
     "framer-motion": "^11.5.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-plaid-link": "^4.1.1"
+    "react-plaid-link": "^5.0.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.28",

--- a/client/src/components/LinkLauncher.tsx
+++ b/client/src/components/LinkLauncher.tsx
@@ -12,7 +12,7 @@ import {
 interface Props {
   isIncome?: boolean;
   token: string;
-  successCallback: (_: string) => Promise<void>;
+  successCallback: (_: string | null) => Promise<void>;
 }
 
 /**
@@ -22,7 +22,7 @@ interface Props {
 export default function LaunchLink(props: Props) {
   // define onSuccess, onExit and onEvent functions as configs for Plaid Link creation
   const onSuccess = async (
-    publicToken: string,
+    publicToken: string | null,
     metadata: PlaidLinkOnSuccessMetadata
   ) => {
     console.log(`Hooray! Public token is ${publicToken}`);

--- a/client/src/components/LinkLoader.tsx
+++ b/client/src/components/LinkLoader.tsx
@@ -32,7 +32,7 @@ const LinkLoader = (props: Props) => {
     }
   };
 
-  const linkSuccess = async (public_token: String) => {
+  const linkSuccess = async (public_token: string | null) => {
     if (public_token != null && public_token !== "") {
       if (props.income) {
         await incomeSuccess(public_token);


### PR DESCRIPTION
5.0.0 corrects the public TypeScript definitions to match the Link Web SDK, so this is a types-only upgrade — runtime behavior is unchanged. One corrected definition reaches this app: `onSuccess` now types `public_token` as `string | null`, so `LaunchLink`'s `onSuccess`, its `successCallback` prop, and `LinkLoader.linkSuccess` widen to match. `linkSuccess` already guarded for a missing token before doing anything with it, so no new logic is needed.