### PR TITLE
Update plaid SDK and fix npm audit advisories

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1536,9 +1536,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -1628,9 +1628,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -1648,7 +1648,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "body-parser": "^1.20.4",
+        "body-parser": "^1.20.6",
         "dotenv": "^16.6.1",
         "express": "^4.22.1",
         "nodemon": "^3.1.11",
-        "plaid": "^41.1.0",
+        "plaid": "^45.0.0",
         "uuid": "^14.0.1"
       },
       "engines": {
@@ -94,13 +94,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
@@ -127,9 +127,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -151,15 +151,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -1026,9 +1026,9 @@
       }
     },
     "node_modules/plaid": {
-      "version": "41.4.0",
-      "resolved": "https://registry.npmjs.org/plaid/-/plaid-41.4.0.tgz",
-      "integrity": "sha512-Ku5W9Ufsa2+TS0/kY8jS6RFPtBUbTq1xNyod89qQt/Jy2L9q9CYAnNL0WlUGa+Y5HEGP990BxCUUS2lGMRxY3g==",
+      "version": "45.0.0",
+      "resolved": "https://registry.npmjs.org/plaid/-/plaid-45.0.0.tgz",
+      "integrity": "sha512-JuK7VKPEdH4muxic35ZyzjFA3Xc+DURkIE/O5A1QQGZfBzOgsQgYBovgGzd/+Z5Jl5dBTV43S9HQX3GSorymUw==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.4"

--- a/server/package.json
+++ b/server/package.json
@@ -11,11 +11,11 @@
   "author": "Todd Kerpelman",
   "license": "MIT",
   "dependencies": {
-    "body-parser": "^1.20.4",
+    "body-parser": "^1.20.6",
     "dotenv": "^16.6.1",
     "express": "^4.22.1",
     "nodemon": "^3.1.11",
-    "plaid": "^41.1.0",
+    "plaid": "^45.0.0",
     "uuid": "^14.0.1"
   },
   "engines": {


### PR DESCRIPTION
Bumps `plaid` 41.1.0 -> 45.0.0 to pick up a patched `axios` (resolves a high-severity DoS/prototype-pollution advisory bundled with the old SDK version), bumps `body-parser` to ^1.20.6, and runs `npm audit fix` in both `client/` and `server/` to clear the remaining `nanoid`, `postcss`, and `brace-expansion` advisories.

<details>
<summary>Verification</summary>

- `npm audit` is clean in both `client/` and `server/`.
- `client` builds successfully with `npm run build`.
- Confirmed the `plaid` v45 client still exposes all methods used in `server/server.js` (`linkTokenCreate`, `itemPublicTokenExchange`, `liabilitiesGet`, `userCreate`, `creditPayrollIncomePrecheck`, `creditPayrollIncomeGet`, `creditBankIncomeGet`, `itemWebhookUpdate`).

</details>